### PR TITLE
remove `sphinx.ext.imgconverter` from sphinx auto-builds

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -21,7 +21,7 @@
     "restructuredtext.updateDelay": 100000,
     "python.testing.unittestEnabled": false,
     "python.testing.nosetestsEnabled": false,
-    "python.testing.pyTestEnabled": true,
+    "python.testing.pytestEnabled": true,
     "python.linting.pylintEnabled": false,
     "python.linting.pylamaEnabled": false,
     "python.linting.enabled": true,

--- a/ipypublish/__init__.py
+++ b/ipypublish/__init__.py
@@ -1,3 +1,3 @@
 from ipypublish.scripts import nb_setup  # noqa: F401
 
-__version__ = '0.10.2'
+__version__ = '0.10.3'

--- a/ipypublish/filters_pandoc/definitions.py
+++ b/ipypublish/filters_pandoc/definitions.py
@@ -65,4 +65,6 @@ CITE_HTML_NAMES = (
 )
 
 RST_KNOWN_ROLES = (
-    "py:attr", "py:meth", "py:class", "py:func", "py:mod")
+    "py:attr", "py:meth", "py:class", "py:func", "py:mod",
+    "attr", "meth", "class", "func", "mod",
+    "download", "doc", "file", "program")

--- a/ipypublish/sphinx/config.yaml
+++ b/ipypublish/sphinx/config.yaml
@@ -24,7 +24,6 @@ extensions: [
     'sphinx.ext.mathjax',  # convert latex math to html
     'sphinxcontrib.bibtex',  # allows for :cite: and .. bibligraphy::
     'sphinx.ext.todo',  # allows for .. todo:: directive
-    'sphinx.ext.imgconverter'  # converts svg to pdf in latex output
 ]
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos: false


### PR DESCRIPTION
It causes builds containing SVG output to fail