### PR TITLE
Improve ipubpandoc filter: conversion of equations

### DIFF
--- a/ipypublish/filters_pandoc/format_label_elements.py
+++ b/ipypublish/filters_pandoc/format_label_elements.py
@@ -21,13 +21,14 @@ will be stripped from the document
 # TODO format headers with section labels
 # (see ipysphinx.transforms.CreateNotebookSectionAnchors)
 import json
+import re
+import textwrap
+
 from panflute import Element, Doc, Span, Div, Math, Image, Table  # noqa: F401
 import panflute as pf
 
 from ipypublish.filters_pandoc.utils import convert_units, convert_attributes
-from ipypublish.filters_pandoc.prepare_labels import (
-    LABELLED_IMAGE_CLASS, LABELLED_MATH_CLASS, LABELLED_TABLE_CLASS
-)
+from ipypublish.filters_pandoc.prepare_labels import (LABELLED_IMAGE_CLASS, LABELLED_MATH_CLASS, LABELLED_TABLE_CLASS)
 
 LATEX_FIG_LABELLED = """\\begin{{figure}}[{options}]
 \\hypertarget{{{label}}}{{%
@@ -45,6 +46,8 @@ LATEX_FIG_UNLABELLED = """\\begin{{figure}}[{options}]
 \\caption{{{caption}}}
 \\end{{figure}}"""  # noqa: E501
 
+MATH_ENVS = ('equation', 'align', 'alignat', 'eqnarray', 'multline', 'gather', 'flalign', 'dmath')
+
 
 def format_math(math, doc):
     # type: (Math, Doc) -> Element
@@ -55,47 +58,50 @@ def format_math(math, doc):
     if not isinstance(math, pf.Math):
         return None
 
-    if math.format != "DisplayMath":
+    if math.format != 'DisplayMath':
         return None
 
-    span = None
-    number = ""
-    env = "equation"
-    label_tag = ""
-    if (isinstance(math.parent, pf.Span)
-            and LABELLED_MATH_CLASS in math.parent.classes):
+    # test if the math text is already wrapped in an environment
+    regex = re.compile(r'\\begin\{{((?:{0})\*?)\}}(.*)\\end\{{((?:{0})\*?)\}}'.format('|'.join(MATH_ENVS)), re.DOTALL)
+    wrap_match = regex.match(math.text)
+
+    env = None
+    label = None
+    if (isinstance(math.parent, pf.Span) and LABELLED_MATH_CLASS in math.parent.classes):
         span = math.parent
+        numbered = '*' if 'unnumbered' in span.classes else ''
+        env = span.attributes.get('env', 'equation') + numbered
+        label = span.identifier
 
-        number = '*' if "unnumbered" in span.classes else ''
-        env = span.attributes.get("env", "equation")
-        if doc.format in ("tex", "latex"):
-            label_tag = "\\label{{{0}}}".format(span.identifier)
+    if doc.format in ('tex', 'latex'):
+        if wrap_match:
+            # TODO edge case where a label has been specified, but the math is already wrapped
+            tex = math.text
         else:
-            label_tag = ""
+            tex = '\\begin{{{0}}}{1}\\label{{{2}}}\\end{{{0}}}'.format(env or 'equation', math.text, label or '')
+        return pf.RawInline(tex, format='tex')
 
-    # construct latex environment
-    tex = '\\begin{{{0}{1}}}{2}{3}\\end{{{0}{1}}}'.format(
-        env, number, math.text, label_tag)
-
-    if doc.format in ("tex", "latex"):
-        return pf.RawInline(tex, format="tex")
-
-    elif doc.format in ("rst"):
-        if not span:
-            rst = '\n\n.. math::\n   :nowrap:\n\n   {0}\n\n'.format(tex)
+    elif doc.format in ('rst'):
+        if env:
+            tex = textwrap.indent('\\begin{{{0}}}{1}\\end{{{0}}}'.format(env, math.text), '   ')
         else:
-            rst = (
-                '\n\n.. math::\n   :nowrap:\n   :label: {0}'
-                '\n\n   {1}\n\n'.format(span.identifier, tex))
-        return pf.RawInline(rst, format="rst")
+            tex = textwrap.indent(math.text.strip(), '   ')
+        rst = '\n\n.. math::\n'
+        if wrap_match or env:
+            rst += '   :nowrap:\n'
+        if label:
+            rst += '   :label: {}\n'.format(label)
+        rst += '\n{}\n\n'.format(tex)
+        return pf.RawInline(rst, format='rst')
 
     elif doc.format in ('html', 'html5'):
         # new_span = pf.Span(anchor_start, math, anchor_end)
         # TODO add formatting
         # TODO name by count
-        if span:
-            math.text = tex
-            return _wrap_in_anchor(math, span.identifier)
+        if label:
+            if not wrap_match:
+                math.text = '\\begin{{{0}}}{1}\\end{{{0}}}'.format(env or 'equation', math.text)
+            return _wrap_in_anchor(math, label)
         else:
             return None
 
@@ -110,8 +116,7 @@ def format_image(image, doc):
         return None
 
     span = None
-    if (isinstance(image.parent, pf.Span)
-            and LABELLED_IMAGE_CLASS in image.parent.classes):
+    if (isinstance(image.parent, pf.Span) and LABELLED_IMAGE_CLASS in image.parent.classes):
         span = image.parent
 
     if span is not None:
@@ -123,41 +128,35 @@ def format_image(image, doc):
         attributes = image.attributes
         # classes = image.classes
 
-    if doc.format in ("tex", "latex"):
+    if doc.format in ('tex', 'latex'):
         new_doc = Doc(pf.Para(*image.content))
         new_doc.api_version = doc.api_version
         if image.content:
-            caption = pf.run_pandoc(json.dumps(new_doc.to_json()),
-                                    args=["-f", "json", "-t", "latex"]).strip()
+            caption = pf.run_pandoc(json.dumps(new_doc.to_json()), args=['-f', 'json', '-t', 'latex']).strip()
         else:
-            caption = ""
+            caption = ''
 
-        options = attributes.get("placement", "")
+        options = attributes.get('placement', '')
         size = ''  # max width set as 0.9\linewidth
-        if "width" in attributes:
-            width = convert_units(attributes['width'], "fraction")
+        if 'width' in attributes:
+            width = convert_units(attributes['width'], 'fraction')
             size = 'width={0}\\linewidth'.format(width)
-        elif "height" in attributes:
-            height = convert_units(attributes['height'], "fraction")
+        elif 'height' in attributes:
+            height = convert_units(attributes['height'], 'fraction')
             size = 'height={0}\\paperheight'.format(height)
 
         if identifier:
-            latex = LATEX_FIG_LABELLED.format(
-                label=identifier,
-                options=options,
-                path=image.url,
-                caption=caption,
-                size=size)
+            latex = LATEX_FIG_LABELLED.format(label=identifier,
+                                              options=options,
+                                              path=image.url,
+                                              caption=caption,
+                                              size=size)
         else:
-            latex = LATEX_FIG_UNLABELLED.format(
-                options=options,
-                path=image.url,
-                caption=caption,
-                size=size)
+            latex = LATEX_FIG_UNLABELLED.format(options=options, path=image.url, caption=caption, size=size)
 
-        return pf.RawInline(latex, format="tex")
+        return pf.RawInline(latex, format='tex')
 
-    elif doc.format in ("rst",):
+    elif doc.format in ('rst',):
         if not image.content.list:
             # If the container is empty, then pandoc will assign an iterative
             # reference identifier to it (image0, image1).
@@ -172,7 +171,7 @@ def format_image(image, doc):
         return image
         # TODO formatting and span identifier (convert width/height to %)
 
-    elif doc.format in ("html", "html5"):
+    elif doc.format in ('html', 'html5'):
         if identifier:
             return _wrap_in_anchor(image, identifier)
         else:
@@ -192,8 +191,7 @@ def format_table(table, doc):
         return None
 
     div = None  # type: pf.Div
-    if (isinstance(table.parent, pf.Div)
-            and LABELLED_TABLE_CLASS in table.parent.classes):
+    if (isinstance(table.parent, pf.Div) and LABELLED_TABLE_CLASS in table.parent.classes):
         div = table.parent
 
     if div is None:
@@ -201,68 +199,53 @@ def format_table(table, doc):
 
     attributes = convert_attributes(div.attributes)
 
-    if "align" in div.attributes:
-        align_text = attributes["align"]
-        align = [
-            {'l': 'AlignLeft',
-             'r': 'AlignRight',
-             'c': 'AlignCenter'}.get(a, None) for a in align_text]
+    if 'align' in div.attributes:
+        align_text = attributes['align']
+        align = [{'l': 'AlignLeft', 'r': 'AlignRight', 'c': 'AlignCenter'}.get(a, None) for a in align_text]
         if None in align:
-            raise ValueError(
-                "table '{0}' alignment must contain only l,r,c:"
-                " {1}".format(div.identifier, align_text))
+            raise ValueError("table '{0}' alignment must contain only l,r,c:" ' {1}'.format(div.identifier, align_text))
         table.alignment = align
-        attributes["align"] = align
+        attributes['align'] = align
 
-    if "widths" in div.attributes:
-        widths = attributes["widths"]
+    if 'widths' in div.attributes:
+        widths = attributes['widths']
         try:
             widths = [float(w) for w in widths]
         except Exception:
-            raise ValueError(
-                "table '{0}' widths must be a list of numbers:"
-                " {1}".format(div.identifier, widths))
+            raise ValueError("table '{0}' widths must be a list of numbers:" ' {1}'.format(div.identifier, widths))
         table.width = widths
-        attributes["widths"] = widths
+        attributes['widths'] = widths
 
-    if doc.format in ("tex", "latex"):
+    if doc.format in ('tex', 'latex'):
         # TODO placement
-        table.caption.append(pf.RawInline(
-            '\\label{{{0}}}'.format(div.identifier), format="tex"))
+        table.caption.append(pf.RawInline('\\label{{{0}}}'.format(div.identifier), format='tex'))
         return table
 
-    if doc.format in ("rst",):
+    if doc.format in ('rst',):
         # pandoc 2.6 doesn't output table options
         if attributes:
             tbl_doc = pf.Doc(table)
             tbl_doc.api_version = doc.api_version
-            tbl_str = pf.convert_text(tbl_doc,
-                                      input_format="panflute",
-                                      output_format="rst")
+            tbl_str = pf.convert_text(tbl_doc, input_format='panflute', output_format='rst')
 
             tbl_lines = tbl_str.splitlines()
-            if tbl_lines[1].strip() == "":
-                tbl_lines.insert(1, "   :align: center")
-                if "widths" in attributes:
+            if tbl_lines[1].strip() == '':
+                tbl_lines.insert(1, '   :align: center')
+                if 'widths' in attributes:
                     # in rst widths must be integers
-                    widths = " ".join([str(int(w*10)) for w in table.width])
-                    tbl_lines.insert(1, "   :widths: {}".format(widths))
+                    widths = ' '.join([str(int(w * 10)) for w in table.width])
+                    tbl_lines.insert(1, '   :widths: {}'.format(widths))
             # TODO rst column alignment, see
             # https://cloud-sptheme.readthedocs.io/en/latest/lib/cloud_sptheme.ext.table_styling.html
 
             return [
-                pf.Para(pf.RawInline(
-                    '.. _`{0}`:'.format(div.identifier), format="rst")),
-                pf.RawBlock("\n".join(tbl_lines)+"\n\n", format=doc.format)
+                pf.Para(pf.RawInline('.. _`{0}`:'.format(div.identifier), format='rst')),
+                pf.RawBlock('\n'.join(tbl_lines) + '\n\n', format=doc.format)
             ]
 
-        return [
-            pf.Para(pf.RawInline(
-                '.. _`{0}`:'.format(div.identifier), format="rst")),
-            table
-        ]
+        return [pf.Para(pf.RawInline('.. _`{0}`:'.format(div.identifier), format='rst')), table]
 
-    if doc.format in ("html", "html5"):
+    if doc.format in ('html', 'html5'):
         return _wrap_in_anchor(table, div.identifier, inline=False)
         # TODO formatting, name by count
 
@@ -270,14 +253,10 @@ def format_table(table, doc):
 def strip_labelled_spans(element, doc):
     # type: (Span, Doc) -> Element
 
-    if isinstance(element, pf.Span) and set(element.classes).intersection([
-        LABELLED_IMAGE_CLASS, LABELLED_MATH_CLASS
-    ]):
+    if isinstance(element, pf.Span) and set(element.classes).intersection([LABELLED_IMAGE_CLASS, LABELLED_MATH_CLASS]):
         return list(element.content)
 
-    if isinstance(element, pf.Div) and set(element.classes).intersection([
-        LABELLED_TABLE_CLASS
-    ]):
+    if isinstance(element, pf.Div) and set(element.classes).intersection([LABELLED_TABLE_CLASS]):
         return list(element.content)
 
 
@@ -291,10 +270,8 @@ def _wrap_in_anchor(element, label, inline=True):
         raw = pf.RawInline
     else:
         raw = pf.RawBlock
-    anchor_start = raw(
-        '<a id="{0}" class="anchor-link" name="#{0}">'.format(
-            label), format="html")
-    anchor_end = raw("</a>", format="html")
+    anchor_start = raw('<a id="{0}" class="anchor-link" name="#{0}">'.format(label), format='html')
+    anchor_end = raw('</a>', format='html')
     return [anchor_start, element, anchor_end]
 
 
@@ -313,8 +290,7 @@ def main(doc=None, strip_spans=True):
     to_run = [format_math, format_image, format_table]
     if strip_spans:
         to_run.append(strip_labelled_spans)
-    return pf.run_filters(to_run,
-                          prepare, finalize, doc=doc)
+    return pf.run_filters(to_run, prepare, finalize, doc=doc)
 
 
 if __name__ == '__main__':

--- a/ipypublish/filters_pandoc/format_label_elements.py
+++ b/ipypublish/filters_pandoc/format_label_elements.py
@@ -22,13 +22,20 @@ will be stripped from the document
 # (see ipysphinx.transforms.CreateNotebookSectionAnchors)
 import json
 import re
-import textwrap
 
 from panflute import Element, Doc, Span, Div, Math, Image, Table  # noqa: F401
 import panflute as pf
 
 from ipypublish.filters_pandoc.utils import convert_units, convert_attributes
 from ipypublish.filters_pandoc.prepare_labels import (LABELLED_IMAGE_CLASS, LABELLED_MATH_CLASS, LABELLED_TABLE_CLASS)
+
+try:
+    from textwrap import indent
+except ImportError:  # added in python 3.3
+
+    def indent(text, prefix):
+        return ''.join(prefix + line for line in text.splitlines(True))
+
 
 LATEX_FIG_LABELLED = """\\begin{{figure}}[{options}]
 \\hypertarget{{{label}}}{{%
@@ -83,9 +90,9 @@ def format_math(math, doc):
 
     elif doc.format in ('rst'):
         if env:
-            tex = textwrap.indent('\\begin{{{0}}}{1}\\end{{{0}}}'.format(env, math.text), '   ')
+            tex = indent('\\begin{{{0}}}{1}\\end{{{0}}}'.format(env, math.text), '   ')
         else:
-            tex = textwrap.indent(math.text.strip(), '   ')
+            tex = indent(math.text.strip(), '   ')
         rst = '\n\n.. math::\n'
         if wrap_match or env:
             rst += '   :nowrap:\n'

--- a/ipypublish/filters_pandoc/tests/test_jinja_filter.py
+++ b/ipypublish/filters_pandoc/tests/test_jinja_filter.py
@@ -4,76 +4,67 @@ from ipypublish.filters_pandoc.utils import create_ipub_meta
 
 def test_basic():
 
-    out_str = jinja_filter(
-        "a", "rst", {}, {}
-    )
-    assert out_str == "a"
+    out_str = jinja_filter('a', 'rst', {}, {})
+    assert out_str == 'a'
 
 
 def test_reference():
 
-    out_str = jinja_filter(
-        "@label", "rst", {}, {}
-    )
-    assert out_str == ":cite:`label`"
+    out_str = jinja_filter('@label', 'rst', {}, {})
+    assert out_str == ':cite:`label`'
 
 
 def test_reference_prefix():
 
-    out_str = jinja_filter(
-        "+@label", "rst", {}, {}
-    )
-    assert out_str == ":numref:`label`"
+    out_str = jinja_filter('+@label', 'rst', {}, {})
+    assert out_str == ':numref:`label`'
 
 
 def test_option_in_nb_meta():
 
-    out_str = jinja_filter(
-        "+@label", "rst", create_ipub_meta({"use_numref": False}), {}
-    )
-    assert out_str == ":ref:`label`"
+    out_str = jinja_filter('+@label', 'rst', create_ipub_meta({'use_numref': False}), {})
+    assert out_str == ':ref:`label`'
 
 
 def test_option_in_cell_meta():
 
-    out_str = jinja_filter(
-        "+@label", "rst", create_ipub_meta({"use_numref": False}),
-        create_ipub_meta({"use_numref": True})
-    )
-    assert out_str == ":numref:`label`"
+    out_str = jinja_filter('+@label', 'rst', create_ipub_meta({'use_numref': False}),
+                           create_ipub_meta({'use_numref': True}))
+    assert out_str == ':numref:`label`'
 
 
 def test_option_in_top_matter():
     # TODO create ipub yaml from IPUB_META_ROUTE
 
-    in_str = "\n".join([
-            "---",
-            "ipub:",
-            "  pandoc:",
-            "    use_numref: true",
-            "",
-            "...",
-            "",
-            "+@label"
-        ])
+    in_str = '\n'.join(['---', 'ipub:', '  pandoc:', '    use_numref: true', '', '...', '', '+@label'])
 
-    out_str = jinja_filter(
-        in_str, "rst", create_ipub_meta({"use_numref": False}), {}
-    )
-    assert out_str == ":numref:`label`"
+    out_str = jinja_filter(in_str, 'rst', create_ipub_meta({'use_numref': False}), {})
+    assert out_str == ':numref:`label`'
 
 
 def test_at_notation_false():
 
-    out_str = jinja_filter(
-        "+@label", "rst", create_ipub_meta({"at_notation": False}), {}
-    )
-    assert out_str == "+ :cite:`label`"
+    out_str = jinja_filter('+@label', 'rst', create_ipub_meta({'at_notation': False}), {})
+    assert out_str == '+ :cite:`label`'
 
 
 def test_remove_filter():
 
-    out_str = jinja_filter(
-        "+@label", "rst", create_ipub_meta({"apply_filters": False}), {}
-    )
-    assert out_str == "+@label"
+    out_str = jinja_filter('+@label', 'rst', create_ipub_meta({'apply_filters': False}), {})
+    assert out_str == '+@label'
+
+
+def test_complex_equation():
+
+    in_source = [
+        '$$\\begin{equation*}\n', 'f(x) = \\left\\{\n', '\\begin{array}{ll}\n', '\\; x \\qquad x \\geq 0 \\\\\n',
+        '\\; 0 \\qquad else\n', '\\end{array}\n', '\\right.\n', '\\end{equation*}$$'
+    ]
+
+    out_string = jinja_filter(''.join(in_source), 'rst', create_ipub_meta({}), {})
+    expected = [
+        '.. math::', '   :nowrap:', '', '   \\begin{equation*}', '   f(x) = \\left\\{', '   \\begin{array}{ll}',
+        '   \\; x \\qquad x \\geq 0 \\\\', '   \\; 0 \\qquad else', '   \\end{array}', '   \\right.',
+        '   \\end{equation*}'
+    ]
+    assert out_string.strip() == '\n'.join(expected)


### PR DESCRIPTION
- Ensure equations that are already wrapped in a math environment are not wrapped twice.
- For RST output, ensure multiline equations are correctly indented