### PR TITLE
Allow configuration of initial section numbering via notebook metadata

### DIFF
--- a/docs/source/metadata_tags.rst
+++ b/docs/source/metadata_tags.rst
@@ -499,6 +499,25 @@ For **slide output**:
 -  the value of slide can be true, “new” (to indicate the start of a new
    slide) or “notes”
 
+Specifying the start section number in slide-shows
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+For **slide output**:
+
+.. code:: json
+
+    {
+        "toc": {
+            "base_numbering": "3",
+        }
+    }
+
+-   the above will set the first section number to 3 rather than 1
+
+-   note that the top-level key is "toc", and *not* "ipub"; this allows
+    the starting section number to be configured using the
+    `toc2 notebook extension <https://github.com/ipython-contrib/jupyter_contrib_nbextensions/tree/master/src/jupyter_contrib_nbextensions/nbextensions/toc2>`__
+
 Captions in a Markdown cell
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/ipypublish/preprocessors/slides_from_markdown.py
+++ b/ipypublish/preprocessors/slides_from_markdown.py
@@ -151,6 +151,8 @@ class MarkdownSlides(Preprocessor):
 
     """
 
+    #header_levels = [4]
+
     column_level = traits.Integer(
         1, min=0, help="maximum header level for new columns (0 indicates no maximum)"
     ).tag(config=True)
@@ -174,8 +176,14 @@ class MarkdownSlides(Preprocessor):
         latexdoc_tags = ["code", "error", "table", "equation", "figure", "text"]
         # break up titles
         cells_in_slide = 0
-        header_levels = []
         final_cells = FinalCells(self.header_slide)
+
+        base_numbering = nb.metadata.toc.base_numbering
+        if base_numbering is not None:
+            header_levels = list(map(lambda x: int(x) - 1, base_numbering.split(".")))
+        else:
+            header_levels = []
+
         for i, cell in enumerate(nb.cells):
 
             # Make sure every cell has an ipub meta tag

--- a/ipypublish/preprocessors/slides_from_markdown.py
+++ b/ipypublish/preprocessors/slides_from_markdown.py
@@ -176,11 +176,17 @@ class MarkdownSlides(Preprocessor):
         cells_in_slide = 0
         final_cells = FinalCells(self.header_slide)
 
-        base_numbering = nb.metadata.toc.base_numbering
-        if base_numbering is not None:
-            header_levels = list(map(lambda x: int(x) - 1, base_numbering.split(".")))
-        else:
-            header_levels = []
+        header_levels = []
+        if nb.metadata.toc is not None:
+            base_numbering = nb.metadata.toc.base_numbering
+            if base_numbering is not None:
+                try:
+                    header_levels = list(map(lambda x: int(x), base_numbering.split(".")))
+                    header_levels[0] -= 1
+                    logging.debug("base_numbering = " + base_numbering)
+                    logging.debug("header_levels = " + str(header_levels))
+                except ValueError:
+                    logger.warn("Invalid toc.base_numbering in notebook metadata")
 
         for i, cell in enumerate(nb.cells):
 

--- a/ipypublish/preprocessors/slides_from_markdown.py
+++ b/ipypublish/preprocessors/slides_from_markdown.py
@@ -177,16 +177,16 @@ class MarkdownSlides(Preprocessor):
         final_cells = FinalCells(self.header_slide)
 
         header_levels = []
-        if nb.metadata.toc is not None:
+        try:
             base_numbering = nb.metadata.toc.base_numbering
-            if base_numbering is not None:
-                try:
-                    header_levels = list(map(lambda x: int(x), base_numbering.split(".")))
-                    header_levels[0] -= 1
-                    logging.debug("base_numbering = " + base_numbering)
-                    logging.debug("header_levels = " + str(header_levels))
-                except ValueError:
-                    logger.warn("Invalid toc.base_numbering in notebook metadata")
+            header_levels = list(map(lambda x: int(x), base_numbering.split(".")))
+            header_levels[0] -= 1
+            logging.debug("base_numbering = " + base_numbering)
+            logging.debug("header_levels = " + str(header_levels))
+        except ValueError:
+            logging.warning("Invalid toc.base_numbering in notebook metadata")
+        except AttributeError:
+            logging.debug("No toc.base_numbering in notebook metadata; starting at 1")
 
         for i, cell in enumerate(nb.cells):
 

--- a/ipypublish/preprocessors/slides_from_markdown.py
+++ b/ipypublish/preprocessors/slides_from_markdown.py
@@ -151,8 +151,6 @@ class MarkdownSlides(Preprocessor):
 
     """
 
-    #header_levels = [4]
-
     column_level = traits.Integer(
         1, min=0, help="maximum header level for new columns (0 indicates no maximum)"
     ).tag(config=True)


### PR DESCRIPTION
Implementation of feature request [#112](https://github.com/chrisjsewell/ipypublish/issues/112)