### PR TITLE
ENH: Use provided language in documentclass

### DIFF
--- a/example/notebooks/Example.ipynb
+++ b/example/notebooks/Example.ipynb
@@ -28,9 +28,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-       "ipub": {
-        "slide": true
-       }
+    "ipub": {
+     "slide": true
+    }
    },
    "source": [
     "## General"
@@ -39,9 +39,9 @@
   {
    "cell_type": "markdown",
    "metadata": {
-       "ipub": {
-        "slide": true
-       }
+    "ipub": {
+     "slide": true
+    }
    },
    "source": [
     "Some markdown text.\n",
@@ -109,6 +109,8 @@
        }
    },
    "source": [
+    "References to \\cref{todo-notes}, \\cref{text-output} and \\cref{images-and-figures}.\n",
+    "\n",
     "References to \\cref{fig:example}, \\cref{tbl:example}, \\cref{eqn:example_sympy} and \\cref{code:example_mpl}.\n",
     "\n",
     "Referencing multiple items: \\cref{fig:example,fig:example_h,fig:example_v}.\n",

--- a/ipypublish/templates/segments/ipy-doc_article.latex-tpl.json
+++ b/ipypublish/templates/segments/ipy-doc_article.latex-tpl.json
@@ -143,7 +143,7 @@
     "document_header_end": [
       "",
       "% clereref must be loaded after anything that changes the referencing system",
-      "\\usepackage{cleveref}",
+      "\\usepackage[((( nb.metadata.ipub.language )))]{cleveref}",
       "\\creflabelformat{equation}{#2#1#3}"
     ]
   }

--- a/ipypublish/templates/segments/ipy-doc_article.latex-tpl.json
+++ b/ipypublish/templates/segments/ipy-doc_article.latex-tpl.json
@@ -8,14 +8,19 @@
       "\\documentclass[10pt,parskip=half,",
       "toc=sectionentrywithdots,",
       "bibliography=totocnumbered,",
-      "captions=tableheading,numbers=noendperiod]{scrartcl}",
-      "",
+      "captions=tableheading,numbers=noendperiod,",
+      "((*- if nb.metadata.ipub: *))",
+      "((*- if nb.metadata.ipub.language: *))",
+      "((( nb.metadata.ipub.language ))),",
+      "((*- endif *))",
+      "((*- endif *))",
+      "]{scrartcl}",
       "((*- if nb.metadata.ipub: *))",
       "((*- if nb.metadata.ipub.language: *))",
       "%\\usepackage{polyglossia}",
       "%\\setmainlanguage{((( nb.metadata.ipub.language )))}",
       "%\\DeclareTextCommandDefault{\\nobreakspace}{\\leavevmode\\nobreak\\ }",
-      "\\usepackage[((( nb.metadata.ipub.language )))]{babel}",
+      "\\usepackage{babel}",
       "((*- endif *))",
       "((*- endif *))",
       ""
@@ -143,7 +148,7 @@
     "document_header_end": [
       "",
       "% clereref must be loaded after anything that changes the referencing system",
-      "\\usepackage[((( nb.metadata.ipub.language )))]{cleveref}",
+      "\\usepackage{cleveref}",
       "\\creflabelformat{equation}{#2#1#3}"
     ]
   }


### PR DESCRIPTION
Currently if the language is provided in the metadata it is not used for `cleveref` automatically. This leads to references created with english naming (fig., eq. etc.) instead of the wanted language naming.

Update: This PR adds the language variable in the template in the `documentclass`.